### PR TITLE
Allow returning an ActiveRecord::Relation to avoid using searchkick

### DIFF
--- a/lib/graphql/searchkick/searchable_extension.rb
+++ b/lib/graphql/searchkick/searchable_extension.rb
@@ -14,8 +14,12 @@ module GraphQL
         query = next_args.delete(:query)
         result = yield(object, next_args)
 
-        model = options[:model_class]
-        LazySearch.new(result, query: query, model_class: model)
+        if defined?(ActiveRecord::Relation) && result.is_a?(ActiveRecord::Relation)
+          result
+        else
+          model = options[:model_class]
+          LazySearch.new(result, query: query, model_class: model)
+        end
       end
     end
   end

--- a/lib/graphql/searchkick/version.rb
+++ b/lib/graphql/searchkick/version.rb
@@ -1,5 +1,5 @@
 module Graphql
   module Searchkick
-    VERSION = "0.2.0"
+    VERSION = '0.3.0'
   end
 end


### PR DESCRIPTION
You can return an `ActiveRecord::Relation` to avoid using Searchkick. This is useful if the user isn't performing a query or you want to only send some requests to Elasticsearch.