### PR TITLE
Pass query to resolve method

### DIFF
--- a/lib/graphql/searchkick/searchable_extension.rb
+++ b/lib/graphql/searchkick/searchable_extension.rb
@@ -11,14 +11,13 @@ module GraphQL
 
       def resolve(object:, arguments:, context:)
         next_args = arguments.dup
-        query = next_args.delete(:query)
         result = yield(object, next_args)
 
         if defined?(ActiveRecord::Relation) && result.is_a?(ActiveRecord::Relation)
           result
         else
           model = options[:model_class]
-          LazySearch.new(result, query: query, model_class: model)
+          LazySearch.new(result, query: next_args[:query], model_class: model)
         end
       end
     end

--- a/spec/graphql/searchkick/searchable_extension_spec.rb
+++ b/spec/graphql/searchkick/searchable_extension_spec.rb
@@ -30,10 +30,10 @@ RSpec.describe GraphQL::Searchkick::SearchableExtension do
     end
     let(:filters) { { where: { name: 'Banana' } } }
 
-    it 'removes `query` from the arguments' do
+    it 'includes `query` from the arguments' do
       expect { |block|
         subject.resolve(object: object, arguments: arguments, context: {}, &block)
-      }.to yield_with_args(object, { test: true })
+      }.to yield_with_args(object, { query: 'Test', test: true })
     end
 
     context 'not a relation object' do


### PR DESCRIPTION
Allows using query in the resolver method. Useful for things like A/B testing or a phased rollout.